### PR TITLE
Fix leaky geams not showing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,6 @@ gem "font-awesome-rails"
 gem 'will_paginate'
 gem 'will_paginate-bootstrap'
 
-gem 'whenever', :require => false
-
 # deployment
 gem 'capistrano', '~> 3.4.0'
 gem 'capistrano-rails', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,6 @@ GEM
       capistrano-bundler (~> 1.1)
     capistrano-rails-console (1.0.2)
       capistrano (>= 3.1.0, < 4.0.0)
-    chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
@@ -218,8 +217,6 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     will_paginate (3.1.8)
     will_paginate-bootstrap (1.0.2)
       will_paginate (>= 3.0.3)
@@ -258,7 +255,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
-  whenever
   will_paginate
   will_paginate-bootstrap
 

--- a/app/models/rubymem_adapter.rb
+++ b/app/models/rubymem_adapter.rb
@@ -1,8 +1,15 @@
-class RubymemAdapter < AdvisoryAdapter.new(:filepath, :gem, :cve,
-                                           :osvdb, :url, :title,
-                                           :date, :description, :cvss_v2,
-                                           :cvss_v3, :patched_versions, :unaffected_versions,
-                                           :related)
+class RubymemAdapter < AdvisoryAdapter.new(
+  :filepath,
+  :gem,
+  :url,
+  :title,
+  :date,
+  :description,
+  :patched_versions,
+  :unaffected_versions,
+  :related
+)
+
   def identifier
     filepath.split("/")[-2..-1].join("-").gsub(".yml", "")
   end

--- a/app/models/rubymem_importer.rb
+++ b/app/models/rubymem_importer.rb
@@ -2,7 +2,7 @@ require_relative File.join(Rails.root, 'lib/git_handler')
 class RubymemImporter
   SOURCE = "rubymem"
   PLATFORM = "ruby"
-  REPO_URL = "https://github.com/rubymem/ruby-advisory-db.git"
+  REPO_URL = "https://github.com/rubymem/ruby-mem-advisory-db.git"
   REPO_PATH = "tmp/importers/rubymem"
 
   def initialize(repo_path = nil, repo_url = nil)

--- a/app/views/advisories/index.html.erb
+++ b/app/views/advisories/index.html.erb
@@ -1,5 +1,5 @@
 <div id="rubymem">
-  <%= render :partial => "shared/header" %> 
+  <%= render :partial => "shared/header" %>
 
   <section>
     <h1>Advisory Archive</h1>
@@ -16,10 +16,6 @@
           Title
         </th>
 
-        <th class="col-sm-2">
-          CVE
-        </th>
-
       </thead>
       <% @advisories.each do |adv| %>
         <tr>
@@ -31,9 +27,6 @@
           </td>
           <td>
             <%= link_to adv.title, advisory_path(adv) %>
-          </td>
-          <td>
-            <%= adv.cve %>
           </td>
         </tr>
       <% end %>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,0 @@
-every 6.hours do
-  runner "RubymemImporter.new.import!"
-end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,0 +1,8 @@
+desc "Import leaky gems from https://github.com/rubymem/ruby-mem-advisory-db "
+namespace :rubymem do
+  task :import => :environment do
+    puts "Importing rubymem leaky gems database..."
+    RubymemImporter.new.import!
+    puts "done."
+  end
+end


### PR DESCRIPTION
closes https://github.com/ombulabs/rubymem.com/issues/17

Fix leaky gems not showing in `https://www.rubymem.com/advisories`

We have to create our own scheduler task to import `https://github.com/rubymem/ruby-mem-advisory-db` to the rubymem.com database. The current import functionality is not meant to work on heroku.